### PR TITLE
修改了根据标签id查询文章的参数名称错误问题

### DIFF
--- a/develop/theme/custom-tag.md
+++ b/develop/theme/custom-tag.md
@@ -223,7 +223,7 @@
 #### 语法格式
 
 ```html
-<@postTag method="listByCategoryId" categoryId="分类 id">
+<@postTag method="listByCategoryId" tagId="分类 id">
 // 返回参数：posts
 </@postTag>
 ```


### PR DESCRIPTION
[修改的地方](https://guqing-blog.oss-cn-hangzhou.aliyuncs.com/QQ截图20190610214731_1560174566915.png)